### PR TITLE
Update documentation homepage

### DIFF
--- a/docs/developer-guide/code-of-conduct.md
+++ b/docs/developer-guide/code-of-conduct.md
@@ -1,0 +1,94 @@
+---
+title: Code of Conduct
+layout: default
+summary: Contributing guidelines and code of conduct for OntoPortal
+parent: Developer Guide
+permalink: /developer-guide/code-of-conduct
+nav_order: 11
+---
+
+1. TOC
+{:toc}
+
+# Contributing to OntoPortal (and BioPortal)
+
+First off, thanks for taking the time to contribute! 👍
+
+The following is a set of guidelines for contributing to BioPortal/OntoPortal software, which is hosted in the [NCBO project](https://github.com/ncbo) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Terms of Service](https://bioportal.bioontology.org/terms). By participating, you are expected to uphold this code.
+
+## I don't want to read this whole thing, I just have a question!
+
+> **Note:** Please don't file an issue to ask a question. You'll get faster results by using the resources below.
+
+We have an official message board where the community chimes in with helpful advice if you have questions.
+
+* [BioPortal message board](https://mailman.stanford.edu/mailman/listinfo/bioontology-support) (includes OntoPortal and Virtual Appliance questions) — or you can just send email to [the moderated list](mailto:support@bioontology.org).
+
+## What should I know before I get started?
+
+### Don't try to install from GitHub source
+
+We encourage anyone wanting to start developing with BioPortal/OntoPortal software to get a copy of the [Virtual Appliance](https://www.bioontology.org/wiki/Category:NCBO_Virtual_Appliance), then submit changes to our repositories based on changes to that code base. Read the Repositories section below for better understanding of our rationale, but basically, we have a lot of installation steps that are a bit one-off.
+
+### BioPortal/OntoPortal repositories
+
+The GitHub ncbo project contains many repositories that are not critical to BioPortal operations. Conversely, there are one or two critical repositories that you do not have access to.
+
+You do have to install several different code bases (repositories) as well as some back-end services. Please contact us for more information via the support list.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+Before creating bug reports, you can check our [issue board](https://app.zenhub.com/workspaces/bioportal-5cd9eda6c115951dc85934af) as you might find out that you don't need to create one. When you are creating a bug report, please include as many details as possible. You can submit it via the support list, or via a ticket in the appropriate ncbo repository, or via the bioportal-project repository.
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+#### Before Submitting A Bug Report
+
+* Perform a cursory search of the [issue repository](https://app.zenhub.com/workspaces/bioportal-5cd9eda6c115951dc85934af) and/or the [support archive](http://ncbo-support.2288202.n4.nabble.com/) to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). If you've determined which repository your bug is related to, create an issue on that repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **If you can describe exactly what time the issue occurred**, we can more confidently review our logs to look for reports related to your issue.
+* **Describe the exact steps which reproduce the problem** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include links to your ontology, the BioPortal page(s) you were visiting, and/or copy/pasteable snippets using [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **What's the name and version of the browser you're using?**
+* **Are you running BioPortal in a virtual machine?** If so, which VM software and which operating systems and versions are used for the host and the guest?
+
+### Requesting Features / Suggesting Enhancements
+
+For simple requests/suggestions, an email to our support list is the simplest route. We will attempt to respond to your email and document your suggestion.
+
+If you want to document a request in more detail, you may use our ticket system as described above for reporting bugs.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on the appropriate repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of OntoPortal the suggestion is related to.
+* **Explain why this enhancement would be useful** to most OntoPortal users.
+* **Specify which version of OntoPortal you're using.**
+
+### Pull Requests
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. Test your code before submitting a pull request.
+2. [Optional] Contact us to discuss your pull request, to be sure we will be able to use it.
+3. Follow the existing style in the software you are modifying.
+4. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing.
+
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.

--- a/docs/developer-guide/how-to-contribute-doc.md
+++ b/docs/developer-guide/how-to-contribute-doc.md
@@ -7,7 +7,7 @@ nav_order: 10
 permalink: /developer-guide/how-to-contribute-doc
 ---
 
-This page describes straightforwardly on how to edit and contribute to this documentation
+This page describes straightforwardly on how to edit and contribute to this documentation. For significant changes, please first discuss the changes via issue, email, or any other method with the owners of this repository. You can also use pull requests on the corresponding GitHub repository.
 
 1. TOC
 {:toc}

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,34 +10,33 @@ permalink: /
 
 ### About us
 
-OntoPortal (formerly known as the NCBO Virtual Appliance or BioPortal Virtual Appliance or NCBO technology) is
-the community-maintained distribution of the BioPortal software (originally developed by the [Stanford Center for Biomedical Informatics Research](https://bmir.stanford.edu/)).
+OntoPortal is an open-source software stack for building ontology and semantic artefact repositories. It originates from BioPortal, developed by the [Stanford Center for Biomedical Informatics Research](https://bmir.stanford.edu/), and from AgroPortal, originally developed at [LIRMM](https://www.lirmm.fr) (Laboratoire d'Informatique, de Robotique et de Microélectronique de Montpellier) and now maintained at INRAE.
 
-The [OntoPortal Alliance](https://ontoportal.org) is the community that maintains this software. It is a consortium of research and infrastructure teams (and one SME) dedicated to promoting the development of ontology repositories –in science and more– based on the collaboratively developed OntoPortal open-source software.
-
-See [OntoPortal Alliance](https://ontoportal.org) website for examples of ontology repositories running this software.
+The [OntoPortal Alliance](https://ontoportal.org) is a consortium of research and infrastructure teams dedicated to promoting semantic services across scientific disciplines. It develops and maintains the shared OntoPortal open-source software, currently powering repositories such as BioPortal, AgroPortal, EcoPortal, and MatPortal, as well as over 135 registered appliance installations worldwide. The Alliance operates as an open community, coordinated through GitHub and sustained through annual workshops.
 
 ### License
 
-This documentation is provided freely for any use by the public (formal license citation pending).
-For License about the OntoPortal software, see each code repositories. 
+The OntoPortal software is distributed under the [BSD-2-Clause license](https://opensource.org/license/bsd-2-clause). For license details of each component, see the corresponding code repositories.
 
 ### Contributing
 
 See the section [How to contribute to the doc]({{site.baseurl}}/developer-guide/how-to-contribute-doc), to know about maintaining and contributing to this documentation.
 
-When contributing to this documentation, for significant changes, please first discuss the changes via issue, email, or any other method with the owners of this repository. You can also use pull requests on the corresponding GitHub repository.
+OntoPortal Alliance is committed to fostering a welcoming community. View our [Code of Conduct]({{site.baseurl}}/developer-guide/code-of-conduct).
 
-OntoPortal support email list: {{site.support_email}}.
 
-Read more about becoming a contributor (for the moment, in our BioPortal repository) in our [Contributing Guide](https://github.com/ncbo/bioportal-project/blob/master/contributing.md).
+### Contact
 
-### Code of conduct
-
-OntoPortal Alliance is committed to fostering a welcoming community. View our [Code of Conduct](https://github.com/ncbo/bioportal-project/blob/master/contributing.md#code-of-conduct) (to be updated from the BioPortal source). 
-
-### Background on technology
-(to come)
+<div style="display:flex; flex-direction:column; gap:0.75rem; margin-top:0.5rem;">
+  <a href="mailto:{{site.support_email}}" style="display:inline-flex; align-items:center; gap:0.6rem; text-decoration:none; color:inherit;">
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+    <span>{{site.support_email}}</span>
+  </a>
+  <a href="https://ontoportalalliance.slack.com/" target="_blank" style="display:inline-flex; align-items:center; gap:0.6rem; text-decoration:none; color:inherit;">
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24"><path fill="#E01E5A" d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52z"/><path fill="#E01E5A" d="M6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313z"/><path fill="#36C5F0" d="M8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834z"/><path fill="#36C5F0" d="M8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312z"/><path fill="#2EB67D" d="M18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834z"/><path fill="#2EB67D" d="M17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312z"/><path fill="#ECB22E" d="M15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52z"/><path fill="#ECB22E" d="M15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg>
+    <span>Join us on Slack</span>
+  </a>
+</div>
 
 
 #### Thank you to the contributors of this documentation!


### PR DESCRIPTION
## Summary

- **About us**: réécriture mentionnant BioPortal (Stanford), AgroPortal (LIRMM/INRAE) et description mise à jour de l'OntoPortal Alliance (membres, 135 installations, open community)
- **License**: remplacé la mention de la licence de la doc par la licence BSD-2-Clause du logiciel
- **Contact**: nouvelle section avec email et Slack (logo SVG officiel)
- **Contributing**: déplacé la note sur les PR significatives vers `how-to-contribute-doc.md`
- **Code of Conduct**: nouvelle page dans le Developer Guide reprenant le contenu de `ncbo/bioportal-project/contributing.md`; liens de la homepage mis à jour

## Test plan

- [ ] Vérifier la page d'accueil `/`
- [ ] Vérifier le lien email (mailto)
- [ ] Vérifier le lien Slack
- [ ] Vérifier le lien Code of Conduct → `/developer-guide/code-of-conduct`
- [ ] Vérifier le lien BSD-2-Clause
- [ ] Vérifier le lien LIRMM

🤖 Generated with [Claude Code](https://claude.com/claude-code)