### PR TITLE
Admin Guide: rename sections and add Joining OntoPortal

### DIFF
--- a/_includes/shared_admin/joining/index.md
+++ b/_includes/shared_admin/joining/index.md
@@ -1,0 +1,6 @@
+# Joining OntoPortal
+
+There are two distinct ways to join the OntoPortal community:
+
+* **[Joining the Alliance]({{site.baseurl}}/administration-guide/joining/joining_the_alliance)**: becoming a member of the OntoPortal Alliance and operating your own customized portal based on the OntoPortal technology.
+* **[Joining the Federation]({{site.baseurl}}/administration-guide/joining/joining_the_federation)**: connecting your existing OntoPortal-based portal to the OntoPortal Federation to enable cross-portal browse, search, and other federated services.

--- a/_includes/shared_admin/joining/joining_the_alliance.md
+++ b/_includes/shared_admin/joining/joining_the_alliance.md
@@ -1,6 +1,16 @@
 # Joining the Alliance
 
-## 1. Fork these 2 projects
+Joining the OntoPortal Alliance means setting up and operating your own portal based on the OntoPortal technology. This section describes the steps involved from installing your own instance, to customizing it and self-declaring your portal on the OntoPortal website so it appears alongside the other portals of the Alliance.
+
+## 0. Install OntoPortal
+
+Before customizing your portal, you first need to install your own instance of OntoPortal. See the [Installation Steps]({{site.baseurl}}/administration-guide/steps/) section for detailed instructions.
+
+## 1. Setup your GitHub environment
+
+Deploying a customized version of OntoPortal — with the same functionalities but with your own look and feel, name, footer, etc., and served at your own specific URL — requires modifying the code's configuration files and re-deploying your own version of the code. This therefore has to be done at least once manually, or by setting up a CI/CD pipeline to automate the build and deployment of your portal.
+
+For this reason, we ask that your code repositories be, whenever possible, **forks of the upstream OntoPortal repositories**. This makes it easier for you to pull in updates and to contribute your changes back to the Alliance. At a minimum, you need to fork the following two repositories:
 
 * <https://github.com/ontoportal/ontoportal_web_ui>
 * <https://github.com/ontoportal/ontologies_api>

--- a/_includes/shared_admin/joining/joining_the_alliance.md
+++ b/_includes/shared_admin/joining/joining_the_alliance.md
@@ -2,9 +2,16 @@
 
 Joining the OntoPortal Alliance means setting up and operating your own portal based on the OntoPortal technology. This section describes the steps involved from installing your own instance, to customizing it and self-declaring your portal on the OntoPortal website so it appears alongside the other portals of the Alliance.
 
-## 0. Install OntoPortal
+## 0. Install OntoPortal and choose domain name
 
 Before customizing your portal, you first need to install your own instance of OntoPortal. See the [Installation Steps]({{site.baseurl}}/administration-guide/steps/) section for detailed instructions.
+
+In parallel, engage in the procedures to get a domain name for your portal. Your are going to need multiple sub-domains. For instance, if you choose myportal.eu, you will need at least: 
+* https://myportal.eu - for the Web application
+* https://data.myportal.eu - for the API
+* https://services.myportal.eu - for the additionnal running services
+* https://sparql.myportal.eu - for the public SPARQL endpoint
+* https://sliceN.myportal.eu - for any of the Slices specific to your portal
 
 ## 1. Setup your GitHub environment
 
@@ -14,49 +21,45 @@ For this reason, we ask that your code repositories be, whenever possible, **for
 
 * <https://github.com/ontoportal/ontoportal_web_ui>
 * <https://github.com/ontoportal/ontologies_api>
-  * Make sure you fork the **agroportal** branch as well.
+* <https://github.com/ontoportal/website>
 
-## 2. Portal Appearance Customization
+## 2. Custom look-and-feel
 
-### 2.1 Choose colors for the portal 
+### 2.1 Choose colors 
 
-We need 4 colors for the portal:
-
-1. Primary color
-2. Hover color
-3. Secondary color
-4. Light color
+We need 4 colors for the portal: (i) Primary color, (ii) Hover color, (iii) Secondary color and (iv)Light color. As described on the image bellow. 
 
  ![](https://wiki.agroportal.eu/api/files.get?sig=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1cGxvYWRzLzVmNTFjMmUyLTZlMDMtNGQzZS04ZWNiLTE2NzJkYTcxN2ZmYi85MDhlNTRiZS1mMGEyLTQzNmYtOTczNy1jMjhiNDg4N2NiMDYvU2NyZWVuc2hvdCAyMDI2LTA2LTA5IGF0IDEyLjAxLjAzLnBuZyIsInR5cGUiOiJhdHRhY2htZW50IiwiaWF0IjoxNzgyODM4MTUxLCJleHAiOjE3ODM0NDI5NTF9.YylvG_Rr_onSm_5gfD2zNpJezl7YtL0Wnd-CI3uwPyI " =431x400")
 
-Then we change them here:
-
-<https://github.com/ontoportal/ontoportal_web_ui/blob/master/app/assets/stylesheets/theme-variables.scss.erb>
+* Change the colors here: <https://github.com/ontoportal/ontoportal_web_ui/blob/master/app/assets/stylesheets/theme-variables.scss.erb>
 
 ### 2.2 Choose the logos to display in the homepage 
 
-* choosing the logos to display and upload them to <https://github.com/ontoportal/ontoportal_web_ui/tree/master/app/assets/images>
+* Choose the logos to display and upload them to <https://github.com/ontoportal/ontoportal_web_ui/tree/master/app/assets/images>
 
  ![](https://wiki.agroportal.eu/api/files.get?sig=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1cGxvYWRzLzVmNTFjMmUyLTZlMDMtNGQzZS04ZWNiLTE2NzJkYTcxN2ZmYi8xNDlkYTNhNi03ZDIxLTQ0MjItOGYyNS00NmZjMzc4ZmU0NTcvU2NyZWVuc2hvdCAyMDI2LTA2LTA5IGF0IDExLjMzLjEyLnBuZyIsInR5cGUiOiJhdHRhY2htZW50IiwiaWF0IjoxNzgyODM4MTUxLCJleHAiOjE3ODM0NDI5NTF9.SdzqzntEquH_KXkSqeVI6UAhWj0JxtBab8uPuVcj5f0 " =1199x202")
 
-### 2.3  Modify the config file
+## 3. Text content customization
 
-<https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/bioportal_config_env.rb.sample>
-
-## 3. Portal Text Customization
-
-The portal text is internationalized, and all changes must be added to these YAML files
+Lookup the text you would like to change for your portal user interface (e.g., portal description on the Home page, examples in serach fields, etc.). All the applciation text is internationalized, and all changes must be done to these YAML files:
 
 * <https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/locales/en.yml>
 * <https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/locales/fr.yml>
 
-## 4. Add yourself to the Alliance Poster
+### 4. Modify the main configuration file
 
-* Add your logo to the alliance poster here : <https://www.figma.com/design/n2tOIfgVlVvFAr3F00Ab5m/Ontoportal-alliance?node-id=0-1&t=xwBAXIAKOH2QTQSf-1>
-* Make a PR to: <https://github.com/ontoportal/website>
+(more details to come)
+<https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/bioportal_config_env.rb.sample>
 
-* To be displayed here: <https://ontoportal.org/about/>
+## 5. Suggest changes to the Alliance website
 
-## 5. Setup Google reCAPTCHA
+* Add your logo to the alliance poster: <https://www.figma.com/design/n2tOIfgVlVvFAr3F00Ab5m/Ontoportal-alliance?node-id=0-1&t=xwBAXIAKOH2QTQSf-1>
+* Make a PR to the website project to declare yourself. Include (i) new poster; (ii) list of portals updated; (iii) list of sponsors.
+
+An example of PR on the web site is done available here: https://github.com/ontoportal/website/pull/19
+
+## 6. Other 
+
+### 6.1 Setup Google reCAPTCHA
 
 * <https://www.google.com/recaptcha/admin/create>

--- a/_includes/shared_admin/joining/joining_the_alliance.md
+++ b/_includes/shared_admin/joining/joining_the_alliance.md
@@ -1,0 +1,52 @@
+# First Steps - ECHOES
+
+## 1. Fork these 2 projects
+
+* <https://github.com/ontoportal/ontoportal_web_ui>
+* <https://github.com/ontoportal/ontologies_api>
+  * Make sure you fork the **agroportal** branch as well.
+
+## 2. Portal Appearance Customization
+
+### 2.1 Choose colors for the portal 
+
+We need 4 colors for the portal:
+
+1. Primary color
+2. Hover color
+3. Secondary color
+4. Light color
+
+ ![](https://wiki.agroportal.eu/api/files.get?sig=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1cGxvYWRzLzVmNTFjMmUyLTZlMDMtNGQzZS04ZWNiLTE2NzJkYTcxN2ZmYi85MDhlNTRiZS1mMGEyLTQzNmYtOTczNy1jMjhiNDg4N2NiMDYvU2NyZWVuc2hvdCAyMDI2LTA2LTA5IGF0IDEyLjAxLjAzLnBuZyIsInR5cGUiOiJhdHRhY2htZW50IiwiaWF0IjoxNzgyODM4MTUxLCJleHAiOjE3ODM0NDI5NTF9.YylvG_Rr_onSm_5gfD2zNpJezl7YtL0Wnd-CI3uwPyI " =431x400")
+
+Then we change them here:
+
+<https://github.com/ontoportal/ontoportal_web_ui/blob/master/app/assets/stylesheets/theme-variables.scss.erb>
+
+### 2.2 Choose the logos to display in the homepage 
+
+* choosing the logos to display and upload them to <https://github.com/ontoportal/ontoportal_web_ui/tree/master/app/assets/images>
+
+ ![](https://wiki.agroportal.eu/api/files.get?sig=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJ1cGxvYWRzLzVmNTFjMmUyLTZlMDMtNGQzZS04ZWNiLTE2NzJkYTcxN2ZmYi8xNDlkYTNhNi03ZDIxLTQ0MjItOGYyNS00NmZjMzc4ZmU0NTcvU2NyZWVuc2hvdCAyMDI2LTA2LTA5IGF0IDExLjMzLjEyLnBuZyIsInR5cGUiOiJhdHRhY2htZW50IiwiaWF0IjoxNzgyODM4MTUxLCJleHAiOjE3ODM0NDI5NTF9.SdzqzntEquH_KXkSqeVI6UAhWj0JxtBab8uPuVcj5f0 " =1199x202")
+
+### 2.3  Modify the config file
+
+<https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/bioportal_config_env.rb.sample>
+
+## 3. Portal Text Customization
+
+The portal text is internationalized, and all changes must be added to these YAML files
+
+* <https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/locales/en.yml>
+* <https://github.com/ontoportal/ontoportal_web_ui/blob/master/config/locales/fr.yml>
+
+## 4. Add yourself to the Alliance Poster
+
+* Add your logo to the alliance poster here : <https://www.figma.com/design/n2tOIfgVlVvFAr3F00Ab5m/Ontoportal-alliance?node-id=0-1&t=xwBAXIAKOH2QTQSf-1>
+* Make a PR to: <https://github.com/ontoportal/website>
+
+* To be displayed here: <https://ontoportal.org/about/>
+
+## 5. Setup Google reCAPTCHA
+
+* <https://www.google.com/recaptcha/admin/create>

--- a/_includes/shared_admin/joining/joining_the_alliance.md
+++ b/_includes/shared_admin/joining/joining_the_alliance.md
@@ -1,4 +1,4 @@
-# First Steps - ECHOES
+# Joining the Alliance
 
 ## 1. Fork these 2 projects
 

--- a/_includes/shared_admin/joining/joining_the_federation.md
+++ b/_includes/shared_admin/joining/joining_the_federation.md
@@ -1,0 +1,5 @@
+# Joining the Federation
+
+This section is under construction. Check back soon for the steps to connect your OntoPortal-based portal to the [OntoPortal Federation]({{site.baseurl}}/user-guide/federation).
+
+In the meantime, see [Setup Federation]({{site.baseurl}}/user-guide/federation/setup_federation) for the current technical instructions on setting up API keys and federated UI/API settings.

--- a/_includes/shared_admin/management/index.md
+++ b/_includes/shared_admin/management/index.md
@@ -1,4 +1,4 @@
-# Managing Your System
+# System Management
 
 The {{site.opva}} requires some routine operational monitoring,
 occasional troubleshooting or corrective actions (more often if heavily used),

--- a/_includes/shared_admin/ontologies/index.md
+++ b/_includes/shared_admin/ontologies/index.md
@@ -1,4 +1,4 @@
-# Managing Ontologies in OntoPortal
+# Managing Content
   
 The {{site.opva}} comes with a few example ontologies already installed.
 You are expected to populate the site with the ontologies that interest you.

--- a/docs/administration-guide/faq.md
+++ b/docs/administration-guide/faq.md
@@ -3,7 +3,7 @@ title: Frequently Asked Questions (FAQ)
 layout: default
 summary: Various common questions about the Appliance
 status: Ready
-nav_order: 7
+nav_order: 6
 parent: Administration Guide
 permalink: /administration-guide/faq
 version: "v32"

--- a/docs/administration-guide/faq.md
+++ b/docs/administration-guide/faq.md
@@ -3,7 +3,7 @@ title: Frequently Asked Questions (FAQ)
 layout: default
 summary: Various common questions about the Appliance
 status: Ready
-nav_order: 5
+nav_order: 7
 parent: Administration Guide
 permalink: /administration-guide/faq
 version: "v32"

--- a/docs/administration-guide/installation/4store_configuration.md
+++ b/docs/administration-guide/installation/4store_configuration.md
@@ -3,7 +3,7 @@ title: 4store Configuration
 summary: Configuring your system to use 4store as RDF backend
 layout: default
 nav_order: 12
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/4store_configuration
 ---

--- a/docs/administration-guide/installation/Enable Recaptcha.md
+++ b/docs/administration-guide/installation/Enable Recaptcha.md
@@ -4,7 +4,7 @@ layout: default
 summary: enable Recaptcha verification for forms in Ontoportal 
 status: In progress
 nav_order: 13
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/enable_recaptcha
 version: "v32"

--- a/docs/administration-guide/installation/advanced_configuration.md
+++ b/docs/administration-guide/installation/advanced_configuration.md
@@ -4,7 +4,7 @@ layout: default
 summary: Configuring more advanced settings
 status: In progress
 nav_order: 4
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/advanced_configuration
 version: "v32"

--- a/docs/administration-guide/installation/allegrograph_configuration.md
+++ b/docs/administration-guide/installation/allegrograph_configuration.md
@@ -4,7 +4,7 @@ layout: default
 summary: Configuring your system to run AllegroGraph
 status: Needs revision
 nav_order: 11
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/allegrograph_configuration
 version: "v32"

--- a/docs/administration-guide/installation/branding_customizations.md
+++ b/docs/administration-guide/installation/branding_customizations.md
@@ -4,7 +4,7 @@ layout: default
 summary: Configuring OntoPortal for your own project
 status: In progress
 nav_order: 7
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/branding-customizations
 version: "v32"

--- a/docs/administration-guide/installation/enable_https.md
+++ b/docs/administration-guide/installation/enable_https.md
@@ -4,7 +4,7 @@ layout: default
 summary: Enable HTTPS
 status: In progress
 nav_order: 5
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/enable_https
 version: "v32"

--- a/docs/administration-guide/installation/getting_started.md
+++ b/docs/administration-guide/installation/getting_started.md
@@ -4,7 +4,7 @@ layout: default
 summary: First steps toward installing the Virtual Appliance
 status: Ready
 nav_order: 1
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/getting_started
 version: "v32"

--- a/docs/administration-guide/installation/index.md
+++ b/docs/administration-guide/installation/index.md
@@ -1,5 +1,5 @@
 ---
-title: Installing OntoPortal
+title: Installation Steps
 layout: default
 summary: Key steps to install the OntoPortal Appliance
 parent: Administration Guide

--- a/docs/administration-guide/installation/index.md
+++ b/docs/administration-guide/installation/index.md
@@ -3,7 +3,7 @@ title: Installation Steps
 layout: default
 summary: Key steps to install the OntoPortal Appliance
 parent: Administration Guide
-nav_order: 2
+nav_order: 3
 has_children: true
 permalink: /administration-guide/steps/
 version: "v32"

--- a/docs/administration-guide/installation/initial_configuration.md
+++ b/docs/administration-guide/installation/initial_configuration.md
@@ -4,7 +4,7 @@ layout: default
 summary: Configuring settings after installation
 status: Needs Revision
 nav_order: 3
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/initial_configuration
 version: "v32"

--- a/docs/administration-guide/installation/initial_installation.md
+++ b/docs/administration-guide/installation/initial_installation.md
@@ -4,7 +4,7 @@ layout: default
 summary: First steps to install your appliance
 status: Ready
 nav_order: 2
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/initial_installation
 version: "v32"

--- a/docs/administration-guide/installation/registration.md
+++ b/docs/administration-guide/installation/registration.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to register your Appliance
 status: Ready
 nav_order: 5
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/registration
 version: "v32"

--- a/docs/administration-guide/installation/setting_up_tools.md
+++ b/docs/administration-guide/installation/setting_up_tools.md
@@ -4,7 +4,7 @@ layout: default
 summary: Configuring the various OntoPortal tools
 status: In progress
 nav_order: 6
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/setting_up_tools
 version: "v32"

--- a/docs/administration-guide/installation/troubleshooting_installations.md
+++ b/docs/administration-guide/installation/troubleshooting_installations.md
@@ -4,7 +4,7 @@ layout: default
 summary: Figuring out why your installation didn't work
 status: In progress
 nav_order: 8
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/troubleshooting_installations
 version: "v32"

--- a/docs/administration-guide/installation/virtualization_environments.md
+++ b/docs/administration-guide/installation/virtualization_environments.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to use the OVF image with your virtualization software
 status: Ready
 nav_order: 9
-parent: Installing OntoPortal
+parent: Installation Steps
 grand_parent: Administration Guide
 permalink: /administration-guide/steps/virtualization_environments
 version: "v32"

--- a/docs/administration-guide/joining/index.md
+++ b/docs/administration-guide/joining/index.md
@@ -1,0 +1,14 @@
+---
+title: Joining OntoPortal
+layout: default
+summary: How to join the OntoPortal Alliance or the OntoPortal Federation
+parent: Administration Guide
+nav_order: 6
+has_children: true
+permalink: /administration-guide/joining/
+version: "v32"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/joining/index.md %}

--- a/docs/administration-guide/joining/index.md
+++ b/docs/administration-guide/joining/index.md
@@ -3,7 +3,7 @@ title: Joining OntoPortal
 layout: default
 summary: How to join the OntoPortal Alliance or the OntoPortal Federation
 parent: Administration Guide
-nav_order: 6
+nav_order: 2
 has_children: true
 permalink: /administration-guide/joining/
 version: "v32"

--- a/docs/administration-guide/joining/joining_the_alliance.md
+++ b/docs/administration-guide/joining/joining_the_alliance.md
@@ -1,0 +1,14 @@
+---
+title: Joining the Alliance
+layout: default
+summary: First steps to set up and customize your own OntoPortal-based portal
+parent: Joining OntoPortal
+grand_parent: Administration Guide
+nav_order: 1
+permalink: /administration-guide/joining/joining_the_alliance
+version: "v32"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/joining/joining_the_alliance.md %}

--- a/docs/administration-guide/joining/joining_the_federation.md
+++ b/docs/administration-guide/joining/joining_the_federation.md
@@ -1,0 +1,14 @@
+---
+title: Joining the Federation
+layout: default
+summary: How to connect your OntoPortal-based portal to the OntoPortal Federation
+parent: Joining OntoPortal
+grand_parent: Administration Guide
+nav_order: 2
+permalink: /administration-guide/joining/joining_the_federation
+version: "v32"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/joining/joining_the_federation.md %}

--- a/docs/administration-guide/management/annotator_management.md
+++ b/docs/administration-guide/management/annotator_management.md
@@ -4,7 +4,7 @@ layout: default
 summary: Operations on the solr search index
 status: Preliminary
 nav_order: 4
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/annotator_management
 version: "v32"

--- a/docs/administration-guide/management/appliance_upgrade.md
+++ b/docs/administration-guide/management/appliance_upgrade.md
@@ -4,7 +4,7 @@ layout: default
 summary: Procedure for upgrading Appliance to new version
 status: Pending
 nav_order: 7
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/appliance_upgrade
 version: "v32"

--- a/docs/administration-guide/management/appliance_upgrade_v25_to_31.md
+++ b/docs/administration-guide/management/appliance_upgrade_v25_to_31.md
@@ -4,7 +4,7 @@ layout: default
 summary: Procedure for upgrading Appliance from v2.5 to v3.1
 status: Pending
 nav_order: 8
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/appliance_upgrade_v25_to_31
 version: "v32"

--- a/docs/administration-guide/management/google_analytics_management.md
+++ b/docs/administration-guide/management/google_analytics_management.md
@@ -4,7 +4,7 @@ layout: default
 summary: Setting up Google Analytics tracking for your Appliance
 status: Preliminary
 nav_order: 5
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/google_analytics_management
 version: "v32"

--- a/docs/administration-guide/management/index.md
+++ b/docs/administration-guide/management/index.md
@@ -3,7 +3,7 @@ title: System Management
 layout: default
 summary: Keeping your OntoPortal Virtual Appliance running smoothly
 parent: Administration Guide
-nav_order: 4
+nav_order: 5
 has_children: true
 permalink: /administration-guide/management/
 version: "v32"

--- a/docs/administration-guide/management/index.md
+++ b/docs/administration-guide/management/index.md
@@ -1,5 +1,5 @@
 ---
-title: Managing Your System
+title: System Management
 layout: default
 summary: Keeping your OntoPortal Virtual Appliance running smoothly
 parent: Administration Guide

--- a/docs/administration-guide/management/monitoring_operations.md
+++ b/docs/administration-guide/management/monitoring_operations.md
@@ -4,7 +4,7 @@ layout: default
 summary: Ways to monitor the OntoPortal Appliance
 status: Preliminary
 nav_order: 1
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/monitoring_operations
 version: "v32"

--- a/docs/administration-guide/management/reference_4store.md
+++ b/docs/administration-guide/management/reference_4store.md
@@ -4,7 +4,7 @@ layout: default
 summary: Advanced information about 4store
 status: Ready
 nav_order: 11
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/reference_4store
 version: "v32"

--- a/docs/administration-guide/management/reference_ncbo-cron.md
+++ b/docs/administration-guide/management/reference_ncbo-cron.md
@@ -4,7 +4,7 @@ layout: default
 summary: Advanced information about ncbo-cron
 status: Preliminary
 nav_order: 9
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/ncbo_cron
 version: "v32"

--- a/docs/administration-guide/management/reference_solr.md
+++ b/docs/administration-guide/management/reference_solr.md
@@ -4,7 +4,7 @@ layout: default
 summary: Advanced information about Solr
 status: Preliminary
 nav_order: 10
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/solr
 version: "v32"

--- a/docs/administration-guide/management/reference_sparql_endpoint.md
+++ b/docs/administration-guide/management/reference_sparql_endpoint.md
@@ -4,7 +4,7 @@ layout: default
 summary: About the OntoPortal SPARQL endpoint
 status: Preliminary
 nav_order: 13
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/reference_sparql_endpoint
 version: "v32"

--- a/docs/administration-guide/management/reference_triple_store_rebuild.md
+++ b/docs/administration-guide/management/reference_triple_store_rebuild.md
@@ -4,7 +4,7 @@ layout: default
 summary: Advanced information about rebuilding the triple store
 status: Pending
 nav_order: 13
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/reference_triple_store_rebuild
 version: "v32"

--- a/docs/administration-guide/management/routine_operations.md
+++ b/docs/administration-guide/management/routine_operations.md
@@ -4,7 +4,7 @@ layout: default
 summary: Performing routine tasks in the OntoPortal system
 status: In progress
 nav_order: 2
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/routine_operations
 version: "v32"

--- a/docs/administration-guide/management/scheduled_maintenance.md
+++ b/docs/administration-guide/management/scheduled_maintenance.md
@@ -4,7 +4,7 @@ layout: default
 summary: OntoPortal tasks you might want to do every so often
 status: Pending
 nav_order: 3
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/scheduled_maintenance
 version: "v32"

--- a/docs/administration-guide/management/search_index_management.md
+++ b/docs/administration-guide/management/search_index_management.md
@@ -4,7 +4,7 @@ layout: default
 summary: Operations on the solr search index
 status: Ready
 nav_order: 4
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/search_index_management
 version: "v32"

--- a/docs/administration-guide/management/troubleshooting_operations.md
+++ b/docs/administration-guide/management/troubleshooting_operations.md
@@ -4,7 +4,7 @@ layout: default
 summary: Solving problems with the Appliance
 status: In progress
 nav_order: 6
-parent: Managing Your System
+parent: System Management
 grand_parent: Administration Guide
 permalink: /administration-guide/management/troubleshooting_operations
 version: "v32"

--- a/docs/administration-guide/ontologies/configuring_ontology_permissions.md
+++ b/docs/administration-guide/ontologies/configuring_ontology_permissions.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to manage access to your repository's ontologies
 status: Pending
 nav_order: 4
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/configuring_ontology_permissions
 version: "v32"

--- a/docs/administration-guide/ontologies/copying_external_ontologies.md
+++ b/docs/administration-guide/ontologies/copying_external_ontologies.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to copy ontologies from another OntoPortal-based repository to your repository
 status: Ready
 nav_order: 2
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/copying_external_ontologies
 version: "v32"

--- a/docs/administration-guide/ontologies/handling_umls.md
+++ b/docs/administration-guide/ontologies/handling_umls.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to submit UMLS content to your repository
 status: Ready
 nav_order: 3
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/handling_umls
 version: "v32"

--- a/docs/administration-guide/ontologies/index.md
+++ b/docs/administration-guide/ontologies/index.md
@@ -1,5 +1,5 @@
 ---
-title: Managing Ontologies in OntoPortal
+title: Managing Content
 layout: default
 summary: Working with ontologies in the OntoPortal Appliance
 parent: Administration Guide

--- a/docs/administration-guide/ontologies/index.md
+++ b/docs/administration-guide/ontologies/index.md
@@ -3,7 +3,7 @@ title: Managing Content
 layout: default
 summary: Working with ontologies in the OntoPortal Appliance
 parent: Administration Guide
-nav_order: 3
+nav_order: 4
 has_children: true
 permalink: /administration-guide/ontologies/
 version: "v32"

--- a/docs/administration-guide/ontologies/managing_ontologies.md
+++ b/docs/administration-guide/ontologies/managing_ontologies.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to manage your repository's ontologies
 status: In Progress
 nav_order: 5
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/managing_ontologies
 version: "v32"

--- a/docs/administration-guide/ontologies/ontology_limitations.md
+++ b/docs/administration-guide/ontologies/ontology_limitations.md
@@ -4,7 +4,7 @@ layout: default
 summary: Kinds of ontologies that OntoPortal can't handle
 status: Ready
 nav_order: 6
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/ontology_limitations
 version: "v32"

--- a/docs/administration-guide/ontologies/parseable_ontologies.md
+++ b/docs/administration-guide/ontologies/parseable_ontologies.md
@@ -4,7 +4,7 @@ layout: default
 summary: The types of ontologies that OntoPortal can handle
 status: Ready
 nav_order: 5
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/parseable_ontologies
 version: "v32"

--- a/docs/administration-guide/ontologies/submitting_ontologies.md
+++ b/docs/administration-guide/ontologies/submitting_ontologies.md
@@ -4,7 +4,7 @@ layout: default
 summary: How to submit ontology files to your repository
 status: Ready
 nav_order: 1
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/submitting_ontologies
 version: "v32"

--- a/docs/administration-guide/ontologies/troubleshooting_submissions.md
+++ b/docs/administration-guide/ontologies/troubleshooting_submissions.md
@@ -4,7 +4,7 @@ layout: default
 summary: Figuring out why your submission didn't work
 status: Ready
 nav_order: 7
-parent: Managing Ontologies in OntoPortal
+parent: Managing Content
 grand_parent: Administration Guide
 permalink: /administration-guide/ontologies/troubleshooting_submissions
 version: "v32"


### PR DESCRIPTION
## Summary

Restructuring and content work on the Administration Guide menu and the new "Joining OntoPortal" section.

- **Rename menu titles to match page headings**
  - "Installing OntoPortal" → **Installation Steps**
  - "Managing Ontologies in OntoPortal" → **Managing Content**
  - "Managing Your System" → **System Management**
  - (front matter titles, shared-content H1s and all child pages' `parent:` references updated)
- **New "Joining OntoPortal" section** (2nd in the menu) with two sub-pages:
  - **Joining the Alliance** — full walkthrough: install + domain names, GitHub fork setup & CI/CD, look-and-feel (colors, logos), text content (i18n YAML), main config file, declaring yourself on the Alliance website, reCAPTCHA.
  - **Joining the Federation** — placeholder cross-referencing the User Guide's Setup Federation page.
- FAQ kept last in the menu after the reordering.

## Test plan (verified on localhost)

- [x] Menu order: General Information, Joining OntoPortal, Installation Steps, Managing Content, System Management, FAQ
- [x] All renamed sections' breadcrumbs and child pages resolve correctly
- [x] New Joining pages render (Alliance content, Federation placeholder)
- [x] No Jekyll build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)