### PR TITLE
Add v4.1 views for 8 version-specific Admin Guide pages

### DIFF
--- a/_includes/shared_admin/installation/v41/allegrograph_configuration.md
+++ b/_includes/shared_admin/installation/v41/allegrograph_configuration.md
@@ -1,0 +1,6 @@
+# AllegroGraph Configuration
+
+{: .note }
+> This page does not apply to **OntoPortal Appliance v4.0 and later**, where **AllegroGraph is already the default RDF triple-store** — there is nothing to switch. See [Triple-store Configuration]({{site.baseurl}}/administration-guide/steps/initial_configuration#triple-store-configuration) for the options available on your appliance.
+
+The switch-from-4store-to-AllegroGraph procedure described in the v3.2 version of this page is only relevant to appliances built **before v4.0**, which shipped with 4store as the default backend.

--- a/_includes/shared_admin/management/v41/annotator_management.md
+++ b/_includes/shared_admin/management/v41/annotator_management.md
@@ -1,0 +1,187 @@
+# Annotator Management
+
+Reference the <a href="{{site.baseurl}}/developer-guide/global_architecture">Architecture</a> page
+for a diagram of the OntoPortal system components.
+
+See the major section below for AnnotatorPlus information.
+
+## Basic operations
+
+The annotator in OntoPortal analyses text files and
+provides matching concepts for strings in the text file.
+To perform this task, the annotator pre-parses every ontology as it is submitted,
+pulling out strings that are appropriate for annotation
+and putting them into a dictionary.
+When a user runs the annotator, it uses mgrep to find strings in the dictionary and
+look up the corresponding class information.
+
+## Technical details
+
+* When each ontology is submitted, it is parsed and the cache and dictionary files are updated
+  * First the annotator cache is created in Redis (localhost:6379),
+  * Then the dictionary.txt file is created from the annotator cache
+* To annotate text, the Annotator ruby lib (https://github.com/ncbo/ncbo_annotator):
+  * The annotator calls mgrep on port 5555
+  * Mgrep retrieves the mgrep ID (first column) from `/srv/ontoportal/data/mgrep/dictionary/dictionary.txt`
+  * Redis uses the mgrep ID to retrieve the class URI and other data (PREF or SYN, ontology URI)
+
+## Operations
+
+### Update the cache and dictionary
+
+#### Using a Redis prefix
+
+When caching data about a concept, Redis uses a prefix.
+This allows the cache to be rebuilt from scratch using a secondary prefix without interrupting the Annotator service using the primary prefix.
+
+To get the prefix used by the annotator in Redis:
+```
+[op-admin@appliance ~]$ redis-cli get current_instance
+"c1:"
+```
+
+To change the prefix used by the annotator in Redis:
+```
+[op-admin@appliance ~]$ redis-cli set current_instance "c2:"
+```
+
+#### Totally clear the cache (optional)
+
+Clearing the cache is not required each time,
+but it can be useful if you have old annotations
+(derived from concepts from deleted submissions) that won't go away.
+
+```
+[op-admin@appliance ~]$ redis-cli get current_instance
+"c1:"
+[op-admin@appliance ~]$ redis-cli --scan --pattern c2:* | xargs redis-cli del
+(integer) 129
+```
+Clearing the cache will also delete the "current_instance", so you will have to set it:
+```
+[op-admin@appliance ~]$ redis-cli set current_instance "c1:"
+OK
+```
+
+### Set up configuration files
+
+Running the generate cache cron job will create new entries in Redis
+using the prefix defined in the config file with `annotator_redis_alt_prefix`.
+
+The locations of the configuration files are:
+* `/opt/ontoportal/ncbo_cron/config/appliance.rb`
+* `/opt/ontoportal/ontologies_api/current/config/environments/appliance.rb`
+
+To generate the cache on a new "alt" prefix while continuing to annotate
+with the prefix defined in Redis current_instance:
+
+```
+Annotator.config do |config|
+  config.annotator_redis_prefix  = ""
+  config.annotator_redis_alt_prefix  = "c1:"
+```
+
+### Generate the Redis cache and dictionary for all ontologies
+
+The following ncbo_cron job will generate the annotator cache in Redis,
+then generate the dictionary used by mgrep (in `/srv/ontoportal/data/mgrep/dictionary/dictionary.txt`).
+
+Be careful! It uses the _annotator_redis_alt_prefix_ to generate the cache,
+but the Redis _current_instance_ to generate the dictionary.
+So if you are doing a total refresh of the cache and dictionary
+(after a flushall, for example)
+you will have to define the same prefix in Redis current_instance and in config.annotator_redis_alt_prefix.
+
+Then run the following command from the ncbo_cron project (`/opt/ontoportal/ncbo_cron`):
+
+```
+[op-admin@appliance ncbo_cron]$ bin/ncbo_ontology_annotate_generate_cache -a -r -d -l log/all_cache.log
+```
+
+It generates an entry in Redis like this: `c1:term:-1762481778059933889`.
+To check for it in Redis:
+```
+[op-admin@appliance ~]$ redis-cli keys c1:term:*
+  1) "c1:term:-6548957943476862587"
+  2) "c1:term:-2190092711777781258"
+  3) "c1:term:-8823641121882305483"
+```
+
+Restart mgrep with `sudo systemctl restart mgrep` or do a `sudo opctl restart` to restart the whole stack.
+
+The annotator should be updated!
+
+#### Details about the generate cache options
+
+The ncbo_cron job `ncbo_ontology_annotate_generate_cache` can be run with different options:
+
+`-r` or `--remove-cache`
+Reset cache to scratch (empty the cache). **Do not** use the `-r` attribute when generating cache for individual ontologies, as it will delete the entire cache used by the Annotator and replace it with a new one that will only contain the given ontologies.
+
+`-a` or `--all-ontologies`
+To generate the cache for all ontologies: run the process on the `annotator_redis_alt_prefix`.
+
+`-o STY,SNMI`
+Generate the cache only for the specified ontologies: run the process on the `annotator_redis_prefix`.
+
+`-d` or `--generate-dictionary`
+Also re-generate the dictionary for the terms prefixed by current_instance. This does the same job as the `ncbo_ontology_annotate_generate_dictionary` ncbo_cron job.
+
+### Generate the dictionary only
+
+To generate the dictionary from the Redis cache (terms prefixed with Redis current_instance):
+
+```
+/opt/ontoportal/ncbo_cron/bin/ncbo_ontology_annotate_generate_dictionary
+```
+
+## Troubleshooting the Annotator
+
+### Check which dictionary mgrep is using
+
+Restart mgrep and run it:
+
+```
+ps -ef | grep mgrep
+```
+
+It should give something like:
+
+```
+mgrep    27924     1  0 Jan27 ?        00:00:00 /usr/local/mgrep-4.0.2/mgrep --port=55555 -f /srv/mgrep/mgrep-55555/dict -w /usr/local/mgrep-4.0.2/word_divider.txt -c /usr/local/mgrep-4.0.2/CaseFolding.txt
+```
+
+### Run queries on mgrep
+
+You can run queries against mgrep directly, using a telnet connection to the mgrep server:
+
+```
+telnet localhost 55555
+  ANY entity
+```
+
+It should return something like this (if the entity is cached for the annotator,
+which it should be since it is in the STY ontology):
+
+```
+1882193402596741431	2	7	entity
+```
+
+# AnnotatorPlus
+
+## Background
+
+AnnotatorPlus is an AgroPortal/SIFR service deployed as a proxy
+on the OntoPortal system in order to serve AnnotatorPlus annotations.
+It runs as a servlet on Tomcat 7.
+
+The core services are provided by http://services.data.bioportal.lirmm.fr.
+
+## Deployment
+
+* AnnotatorPlus is found at `http://{my-appliance-hostname}/annotatorplus`
+* The API is found at `https://{my-appliance-hostname}:8443/annotatorplus`
+
+Note that the AnnotatorPlus documentation has not been updated in the OntoPortal online documentation page at `https://{my-appliance-hostname}:8443/documentation`.
+
+There is more detailed documentation in the [publication supplement](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5972606/bin/bty009_supplement_bioinf-2017-1427.r2-3.pdf) which is pointed to by the [main paper about this capability](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5972606/).

--- a/_includes/shared_admin/management/v41/google_analytics_management.md
+++ b/_includes/shared_admin/management/v41/google_analytics_management.md
@@ -1,0 +1,108 @@
+# Google Analytics Management
+
+## Adding Google Analytics to the {{site.opva}}
+
+BioPortal uses the Google API to process our website data.
+
+If you want to use Google Analytics on your OntoPortal site,
+you will need a Google developer account to use the Google API,
+and a Google Analytics account to see the analytics.
+The Google API is used to process the website's data.
+
+### Google Developer Account
+
+You can create an account at `https://console.developers.google.com/project`.
+Use the following steps to do so.
+
+* Create an account
+* Generate credentials (p12 key & email) and save it for later
+  * API Manager > Credentials > Add credentials > Service account
+  * Note: default password of the p12 keys is `notasecret`
+* Enable Analytics API
+  * API Manager > Overview > Advertising APIs > Analytics API
+* Copy the p12 keys to the appliance (in the `/srv` directory, for example)
+  * Example: `scp myontoportal-analytics.p12 {my_appliance_hostname}:/srv/ontoportal/virtual_appliance/config/ncbo_cron`
+
+### Google Analytics Account
+
+You use Google Analytics to get your website's data.
+
+* Create an account at `https://www.google.com/analytics/web`
+* Add the "tracking ID" of this account in `/srv/ontoportal/virtual_appliance/appliance_config/site_config.rb`
+  * Example: `$ANALYTICS_ID = "UA-12345678-1"`
+* Give permission to your developer credential (previously generated in the Google Developer Account step) to be able to retrieve the data
+  * Admin tab > Property (typically, the website you are doing analytics on) > User Management
+  * Add permissions for the Google developer credential email (also generated in the previous section)
+
+### Google Analytics Configuration
+
+* Modify `/srv/ontoportal/virtual_appliance/appliance_config/ncbo_cron/config/config.rb`
+  * Set up configuration for Google Analytics Data (GA4)
+    ```
+    # Google Analytics CRON config
+    config.enable_ontology_analytics         = true
+    config.cron_ontology_analytics           = '30 */4 * * *'
+    # GA4 Key file used for authentication with Google
+    config.analytics_path_to_key_file        = "config/myontoportal_analytics_key.json"
+    # your GA4 property ID
+    config.analytics_property_id             = "111111111"
+    # path to the file that stores your Universal Analytics (UA) data (if it exists)
+    config.analytics_path_to_ua_data_file    = "data/op_ua_data.json"
+    # path to the file that will store your entire Google Analytics Data
+    # it's a backup copy of your data in addition to storing it in Redis
+    # this file will be auto-created if it doesn't exist already
+    config.analytics_path_to_ga_data_file    = "data/op_ga_data.json"
+    ```
+
+* Perform deployment of UI, API and ncbo_cron, which will copy configuration files to the appropriate application directories:
+  ```bash
+  sudo su - op-admin
+  cd /opt/ontoportal/virtual_appliance/deployment
+  ./setup_deploy_env.sh
+  ./deploy_ui.sh
+  ./deploy_ncbo_cron.sh
+  ```
+
+## Enabling the Analytics Cron Job
+
+The Analytics data is stored in the Redis data store and is scheduled to be refreshed weekly. The refresh is done via an automatically scheduled Cron job. By default, that Cron job is disabled in the OntoPortal Appliance. Below are the steps to enable the Analytics refresh job:
+
+* Restart ncbo_cron services:
+  ```
+  sudo systemctl stop ncbo_cron
+  sudo systemctl start ncbo_cron
+  ```
+
+By default, the Analytics refresh job is scheduled to run on Mondays at 12:15am. If you need to change the frequency or the run time, you can add the parameter `config.cron_ontology_analytics = "your cron expression"` to the `NcboCron.config do |config|` block:
+```
+config.cron_ontology_analytics = "15 0 * * 1"
+```
+
+If you modify this setting, be sure to restart ncbo_cron services (see previous step).
+
+If you need to manually refresh the Analytics data without having to wait for the Cron job to execute, you can run the `ncbo_ontology_analytics_rebuild` script, located in the `ncbo_cron/bin` folder:
+```bash
+sudo su - op-admin
+cd /opt/ontoportal/ncbo_cron
+./bin/ncbo_ontology_analytics_rebuild
+```
+
+The script does not require any arguments; simply execute it, and your Analytics data will be pulled from Google Analytics into the Redis datastore and will be immediately picked up by your OntoPortal services. Note that this step is optional. It should be used only when you need the absolute latest Analytics data and you don't want to wait until the Analytics Cron job gets executed.
+
+## Removing Analytics from the OntoPortal UI
+
+In `/opt/ontoportal/bioportal_web_ui/current/app/views/home/index.html.haml` add:
+
+```
+ display: none;
+ %fieldset{style: "display: none;"}
+  %legend
+   Ontology Visits #{"in full #{$SITE} " if at_slice?} (#{@analytics.date.strftime("%B %Y")})
+```
+
+In `/opt/ontoportal/bioportal_web_ui/current/app/views/ontologies/_visits.html.haml` add:
+
+```
+ display:none;
+ #visits_content{:style => "margin: 2em 1em 0;"}
+```

--- a/_includes/shared_admin/management/v41/reference_ncbo-cron.md
+++ b/_includes/shared_admin/management/v41/reference_ncbo-cron.md
@@ -1,0 +1,190 @@
+# Introduction
+
+This is an advanced reference document on the ncbo-cron utility.
+
+# Debug Cron Job
+
+* The code is deployed to `/opt/ontoportal/ncbo_cron`.
+* There is a log for the scheduler under `logs/scheduler.log`.
+  * Each ontology gets its own log under the ontology's repo folder,
+  * `/srv/ontoportal/data/repository/STY/1/STY_parsing.log`.
+  * This file name is output to the `scheduler.log` file when parsing starts.
+* Useful log file greps:
+
+```
+# get a list of new ontology submissions
+grep 'new submission' /opt/ontoportal/ncbo_cron/log/scheduler-pull.log
+# get a list of errors
+grep 'ERROR' /opt/ontoportal/ncbo_cron/log/scheduler-pull.log
+# get a list of errors with 20 lines of traceback for each
+grep -A20 'ERROR' /opt/ontoportal/ncbo_cron/log/scheduler-pull.log
+```
+
+# Check processing queue
+
+To show cron queued jobs:
+`bundle exec bin/ncbo_cron --view-queue`
+
+Alternatively you can check the `parseQueue` key directly in Redis:
+
+```
+redis-cli hgetall parseQueue
+1) "sub:http://data.bioontology.org/ontologies/STY/submissions/1"
+2) "{\"process_rdf\":true,\"index_search\":true,\"index_properties\":true,\"run_metrics\":true,\"process_annotator\":true,\"diff\":true}"
+```
+
+# Run ncbo-cron jobs
+
+## Default production job
+
+The production scheduler start command is something like:
+
+```
+bin/ncbo_cron -d -c "30 */4 * * *" -h "ncboprod-redis1" -l debug -f "00 17 *  * 4" -w "00 * * * *"
+```
+
+This does the following operations:
+* Pull runs every 4 hours at 30 min.
+* Flush of the graphs runs every Friday at 5pm.
+* Warms up long-running queries every hour at 00 min.
+
+See below for additional ncbo-cron invocations.
+
+By default `ncbo_cron` will not process UMLS ontologies. To enable UMLS processing use `--enable-umls`. This option can trigger heavy parsing so it should be used with care.
+
+## More information about running ncbo-cron
+
+```
+# See script to run the scheduler as a daemon in the bin folder:
+#
+# Only run it as the op-admin user.
+# The option to stop the daemon is -k
+# The startup invocation is more complicated; try searching the ncbo-deployer user's history for any
+# command with 'ncbo_cron -d' in it (that's the daemonize option).
+#
+op-admin@demo:/opt/ontoportal/ncbo_cron$ bin/ncbo_cron --help
+(LD) >> Using rdf store localhost:10035/repositories/ontoportal
+(LD) >> Using term search server at http://localhost:8983/solr/term_search_core1
+(LD) >> Using property search server at http://localhost:8983/solr/prop_search_core1
+(LD) >> Using HTTP Redis instance at localhost:6380
+(LD) >> Using Goo Redis instance at localhost:6381
+(AN) >> Using ANN Redis instance at localhost:6379
+(CR) >> Using Redis instance at localhost:6379
+Usage: ncbo_cron [options]
+    -d, --daemon                     Daemonize mode
+    -k, --kill [PORT]                Kill specified running daemons - leave blank to kill all.
+    -p, --port PORT                  Specify port
+                                     (default: )
+    -P, --pid FILE                   save PID in FILE when using -d option.
+                                     (default: /opt/ontoportal/ncbo_cron/ncbo_cron.pid)
+    -l, --log FILE                   Logfile for output
+                                     (default: /var/log/ontoportal/ncbo_cron/scheduler.log)
+    -u, --user USER                  User to run as
+    -G, --group GROUP                Group to run as
+        --console                    REPL for working with scheduler
+    -v, --view-queue                 view queued jobs
+    -a, --add-submission ID          submission id to add to the queue
+    -h, --redis-host HOST            redis host (for shared locking)
+                                     (default: localhost)
+        --redis-port PORT            redis port (for shared locking)
+                                     (default: 6379)
+        --log-level LEVEL            set the log level (debug, info, error)
+                                     (default: info)
+```
+
+# ncbo-cron scripts
+
+These scripts should be considered experimental until this text is removed.
+Please use them at your own risk.
+
+## Connecting to ncbo-cron
+
+After connecting to your system with ssh, login as `op-admin` and go to the ncbo_cron project.
+
+```
+sudo su - op-admin
+cd /opt/ontoportal/ncbo_cron/
+```
+
+For easy access to the above, start a `screen` session after the ssh connection,
+then use `screen -r` to reconnect to the same login session every time.
+
+## The ncbo-cron scripts
+
+These scripts work on the most recent submission; not necessarily the latest 'ready' submission.
+
+### Read-only scripts
+
+* Script to run diagnostics on all ontologies (most recent submissions)
+
+```
+# Creates output files in logs/submission_status*
+./bin/ncbo_ontology_diagnostics.sh
+```
+
+* Report format for ontologies
+
+```
+./bin/ncbo_ontology_format -h
+```
+
+* Generic ontology inspector
+
+```
+./bin/ncbo_ontology_inspector -h
+```
+
+* Create/Update a ticket for ontology submissions that fail to parse
+
+1. Log into the ncbo_cron system (stage or prod) and run:
+
+```
+$ sudo su - op-admin
+$ cd /opt/ontoportal/ncbo_cron
+$ bundle exec ./bin/ncbo_ontology_inspector -p submissionStatus -o {ONT_ACRONYM} --get_parsing_logs
+```
+
+Notes:
+* the last option `--get_parsing_logs` will retrieve the logs and post them to a JIRA issue automatically; the issue summary/title will be: "{ONT_ACRONYM} submission has ERROR_RDF"; the attachments and comments will indicate what submission fails to parse (and whether it is in stage or prod).
+* the automated JIRA update will reopen a resolved or closed issue (it will not create a new issue every time an ontology has a submission that fails to parse).
+* this option is not enabled by default in the daily diagnostics script; it could be, but if it were enabled it could duplicate data in JIRA every day until the ERROR_RDF status is fixed.
+
+2. Find the relevant JIRA issue by typing 'submission has ERROR_RDF' into the 'Quick Search' field at top right, i.e.
+
+```
+https://bmir-jira.stanford.edu/issues/?jql=summary%20~%20%22submission%20has%20ERROR_RDF%22
+```
+
+The issue will contain comments and parsing logs (reported by the Jenkins user).
+
+## Read-Write scripts
+
+* Process an ontology
+
+```
+./bin/ncbo_ontology_process -h
+```
+
+* Annotate an ontology
+
+```
+./bin/ncbo_ontology_annotate_generate_cache -h
+```
+
+* Calculate and save ontology index in SOLR (see option to index all ontologies)
+
+```
+./bin/ncbo_ontology_index -h
+```
+
+* Calculate and save ontology metrics
+
+```
+./bin/ncbo_ontology_metrics -h
+```
+
+* Generate a new annotation dictionary file
+
+```
+./bin/ncbo_ontology_annotate_generate_dictionary -h
+```

--- a/_includes/shared_admin/management/v41/routine_operations.md
+++ b/_includes/shared_admin/management/v41/routine_operations.md
@@ -1,0 +1,67 @@
+# Routine Operations
+
+## Administrative Web User Interface
+
+### Troubleshoot ontology submissions: Ontologies tab
+
+See the [Troubleshooting Submissions]({{site.baseurl}}/administration-guide/ontologies/troubleshooting_submissions) page
+for detailed instructions on troubleshooting ontology submissions.
+
+See the [Managing Ontologies]({{site.baseurl}}/administration-guide/ontologies/managing_ontologies) page
+to learn more about basic operations like updating ontology metadata, deleting ontologies,
+and reparsing ontologies.
+
+### Caching
+
+#### How can I clear the memcached-based UI cache?
+
+If you are logged in as the admin user, simply visit `http://{your_appliance_ip_or_domain_name}/admin` and click the "Flush Memcache" button. There should be a response indicating success or failure.
+
+## Reset a user's API key
+
+OntoPortal provides a Rake task to easily reset the API key of a user (if it has been exposed or abused).
+
+Optionally view the list of available Rake tasks with their descriptions:
+
+```
+$ cd /opt/ontoportal/ncbo_cron
+$ bundle exec rake -T
+rake cache:clear                                          # Clear HTTP cache (redis and Rack::Cache)
+rake group:add_ontology[group_acronym,ontology_acronym]  # Add ontology to a group
+rake group:create[acronym,name]                          # Create a new ontology group
+rake test                                                # Run tests
+rake user:adminify[username]                             # Add administrator role to the user
+rake user:apikey:get[username]                           # get APIKEY for the user
+rake user:apikey:reset[username,apikey]                  # reset APIKEY for the user to random value or to specified value if API key is provided
+rake user:artifacts[username]                            # Show all artifacts administered by the user
+rake user:create[username,email,password]                # Create a new user
+rake user:resetpassword[username]                        # Reset password to a random value for the user
+rake user:resetroles[username]                           # Reset all roles to LIBRARIAN for the user
+```
+
+Reset a user's API key to a randomly generated value:
+
+```
+$ cd /opt/ontoportal/ncbo_cron
+$ bundle exec rake user:apikey:reset[username]
+```
+
+OntoPortal uses UUIDs for API keys, which can be generated with the `uuidgen` command-line utility and can be explicitly set when resetting API keys:
+
+```
+$ uuidgen
+cf304210-4715-424a-a48d-7ec04fc8924f
+$ cd /opt/ontoportal/ncbo_cron
+$ bundle exec rake user:apikey:reset[username,cf304210-4715-424a-a48d-7ec04fc8924f]
+```
+
+## Grant administrative privileges to a user
+
+```
+cd /opt/ontoportal/ncbo_cron
+bundle exec rake user:adminify[username]
+```
+
+## Stopping and starting services
+
+Services can be controlled with `sudo systemctl stop/start <service>`, or the whole stack can be restarted with `sudo opctl restart`.

--- a/_includes/shared_admin/management/v41/search_index_management.md
+++ b/_includes/shared_admin/management/v41/search_index_management.md
@@ -1,0 +1,55 @@
+# Search Index Management
+
+Reference the <a href="{{site.baseurl}}/developer-guide/global_architecture">Architecture</a> page
+for a diagram of the OntoPortal system components.
+
+## Basic operations
+
+The search index is maintained continuously in Solr.
+When an ontology is submitted, the ontology is re-indexed,
+and the new index entries replace the existing index entries for that ontology.
+
+Re-indexing of individual ontologies can be initiated via the OntoPortal web Admin interface, and it can also be done from the Linux command-line interface on the Appliance. If the whole index becomes corrupted or if the Solr schema is changed, then all the ontologies must be re-indexed.
+
+## Access to the Solr index
+
+Solr runs on port 8983, which is blocked by the local firewall because it is not intended to be accessed directly. Most of the typical Solr administrative operations can be accomplished from the appliance console using the Solr API. If you need to access the Solr web admin interface from outside of the appliance, then you would need to set up SSH port forwarding.
+
+### About the Solr cores
+
+There are 4 index cores:
+* `term_search_core1` is used for term searching operations
+* `prop_search_core1` is used for property searching operations
+* `term_search_core2` and `prop_search_core2` are secondary, non-active cores which can be optionally used for reindexing all ontologies from scratch without interrupting search operations in OntoPortal.
+
+## Re-indexing
+
+### Re-index all ontologies
+
+```bash
+sudo su - op-admin
+cd /opt/ontoportal/ncbo_cron
+bin/ncbo_ontology_index -a -l log/reindexing_all.log
+```
+
+Re-indexing all ontologies deletes all data from the index and starts populating it from scratch. During this time, Appliance search operations will not work as expected because of the incomplete data, until it is fully populated. If you have a large amount of ontologies and are unable to take the site down for maintenance, then you have the option to re-index all ontologies using an alternate core and swap cores after re-indexing is complete.
+
+The first step is to re-index all ontologies using the secondary core:
+```bash
+sudo su - op-admin
+cd /opt/ontoportal/ncbo_cron
+bin/ncbo_ontology_index -a -l log/reindexing_all.log -c http://localhost:8983/solr/term_search_core2
+```
+then swap cores after the reindexing process is complete:
+```
+curl 'http://localhost:8983/solr/admin/cores?action=SWAP&core=term_search_core1&other=term_search_core2'
+```
+[Solr reference for swapping cores](https://lucene.apache.org/solr/guide/8_2/coreadmin-api.html#CoreAdminAPI-Input.4)
+
+### Re-index specified ontologies
+
+You can re-index specific ontologies that you specify.
+
+```
+bin/ncbo_ontology_index -o STY,SNOMED -l log/reindexing_STY_SNOMED.log
+```

--- a/_includes/shared_admin/ontologies/v41/managing_ontologies.md
+++ b/_includes/shared_admin/ontologies/v41/managing_ontologies.md
@@ -1,0 +1,156 @@
+# Managing Ontologies
+
+## Using the Administration Console
+
+If you are logged in as an administrator,
+you will see an Admin link to the left of your profile information.
+Clicking on the Admin link takes you to the OntoPortal Administration Console.
+
+Within that page, click on the Ontology Administration tab to work with ontologies.
+
+Additional information about this capability is presented in the
+Ontology Administration tab of the Administration Console page.
+See <a href="{{site.baseurl}}/administration-guide/ontologies/troubleshooting_submissions">Troubleshooting Submissions</a> for more information.
+
+## Organizing ontologies in OntoPortal
+
+### How do I add or change slices in OntoPortal?
+
+A slice presents a view of OntoPortal that only contains
+ontologies tagged with that slice.
+
+There is no user interface to perform this task.
+Slices can be added using a console
+after logging into the Appliance as the `op-admin` user.
+
+From the bash shell:
+
+```bash
+cd /opt/ontoportal/ncbo_cron
+bin/ncbo_cron --console
+# once in the ruby console:
+ont1 = LinkedData::Models::Ontology.find("ONT1").first
+ont2 = LinkedData::Models::Ontology.find("ONT2").first
+slice = LinkedData::Models::Slice.new
+slice.name = "My Slice",
+slice.description = "This is my custom slice",
+slice.acronym = "my_slice",
+slice.ontologies = [ont1, ont2]
+slice.save
+```
+
+### How do I add or change categories or groups for ontologies?
+
+There is no user interface to perform this task.
+Categories and groups can be added using a console
+after logging into the Appliance as the `op-admin` user.
+
+Use the ncbo_cron rake task:
+```
+cd /opt/ontoportal/ncbo_cron
+bundle exec rake group:create['UMLS','Unified Medical Language System']
+```
+or use the ncbo_cron console:
+
+```
+cd /opt/ontoportal/ncbo_cron
+bin/ncbo_cron --console
+# once in the ruby console:
+category = LinkedData::Models::Category.new
+category.name = "My Category"
+category.acronym = "MY_CAT"
+category.save
+group = LinkedData::Models::Group.new
+group.name = "My Group"
+group.acronym = "MY_GRP"
+group.save
+```
+
+### How do I add an ontology to a group?
+
+There is no user interface to perform this task.
+
+```
+po = LinkedData::Models::Ontology.find("PO").first
+po.bring_remaining
+obo_f = LinkedData::Models::Group.find("OBO_Foundry").first
+group = po.group
+group = group.dup
+group << obo_f
+po.group = group
+po.valid?
+po.save
+```
+
+## Deleting an ontology
+
+You can delete an ontology on the Admin page (as the admin user).
+Click on the row (or rows) of the ontology you want to delete,
+select the Group Action "Delete ontology", and press the Execute button.
+
+Deleting can also be done using a console
+after logging into the Appliance as the `op-admin` user.
+
+{: .note }
+> Verify these instructions.
+
+From the bash shell:
+
+```
+cd /opt/ontoportal/ncbo_cron
+bin/ncbo_cron --console
+# once in the ruby console:
+ontology = LinkedData::Models::Ontology.find("MY_ONTOLOGY_ACRONYM").first
+ontology.delete
+```
+
+# Working with caches
+
+## HTTP caching
+
+### Clear entire cache
+
+Go to the administrator page and click on the button Clear HTTP Cache.
+
+OR
+
+Go to an ontologies_api project and run:
+
+```
+rake cache:clear:production
+```
+
+OR
+
+```
+rake cache:clear:development
+```
+
+### Clear cache for specific objects
+
+Each model gets cached by type (collection) and in segments (by ontology, for example).
+
+Here is an example structure for the cache:
+
+- collection: ontologies
+  - segment: SNOMEDCT
+    - related to segment SNOMEDCT:
+      - classes
+      - submissions
+      - notes
+
+Invalidating the cache is a cascading action,
+meaning that higher-level caches will get invalidated automatically when invalidating lower-level caches.
+For example, invalidating the SNOMEDCT ontology instance will also invalidate the ontologies collection cache (the list of all ontologies).
+
+#### Example of cache invalidation
+
+This will clear the ontology metadata and class objects for a given ontology (RADLEX).
+
+```ruby
+radlex = LinkedData::Models::Ontology.find("RADLEX").first
+radlex.cache_invalidate
+cls = radlex.latest_submission.roots.first
+cls.submission.bring(:ontology)
+cls.cache_invalidate
+```

--- a/_includes/shared_admin/ontologies/v41/submitting_ontologies.md
+++ b/_includes/shared_admin/ontologies/v41/submitting_ontologies.md
@@ -1,0 +1,70 @@
+# Submitting Ontologies
+
+You can add an ontology using the OntoPortal Admin User at `http://{ip_address_of_appliance}/ontologies/new`.
+The ncbo_cron project is configured to automatically process any new ontologies
+every 5 minutes (see the <a href="{{site.baseurl}}/administration-guide/steps/initial_installation">documentation for enabling the scheduler</a>).
+
+The ontology processing includes:
+* Parsing any new, unparsed ontologies
+* Calculating a set of metrics for these ontologies
+* Indexing these ontologies for use with search
+* Processing the ontology for use with the annotator
+
+## As an OntoPortal user with the UI
+
+A regular user of OntoPortal can submit ontologies by going to the Browse page
+and clicking on the `Submit Ontology` button.
+
+The first metadata form asks about characteristics of the ontology.
+Once this form is complete, the user is prompted for information about
+the first _submission_ (version) of the ontology.
+
+Detailed information for submitting ontologies can be found online
+in the documentation found at your appliance at
+`https://{my_appliance_hostname}/documentation`,
+or in the <a href="https://www.bioontology.org/wiki/BioPortal_Help#Submitting_an_ontology">BioPortal documentation on submissions</a>.
+
+## As an OntoPortal user with the API
+
+Information on submitting ontologies via the API is provided at the <a href="http://data.bioontology.org/documentation#OntologySubmission">BioPortal API documentation on submissions</a>, or in your own OntoPortal installation's API documentation.
+
+## Manually reparsing (as a developer) in the scripting environment
+
+The <a href="https://github.com/ncbo/ncbo_cron/blob/master/bin/ncbo_ontology_process">ncbo_ontology_process</a> script
+can be used to easily submit an ontology, if the dependencies associated with deploying the system are in place.
+
+To manually reparse an ontology, you need to ssh into the system and run the `ncbo_ontology_process` script after switching to the `op-admin` user:
+
+```bash
+# from the shell:
+sudo su - op-admin
+cd /opt/ontoportal/ncbo_cron
+bin/ncbo_ontology_process -o ONTOLOGY_ACRONYM
+```
+
+## How do I know if an ontology has parsed?
+
+The OntoPortal Web UI will cache old information about ontologies for 60 seconds. After parsing is complete, just refresh the ontology summary page to see the status for the most recent submission listed under the "Submissions" table.
+
+In addition, you can look at the REST service directly, which will always give you the most updated information. To do this, visit the following URL:
+
+`https://{your_appliance_ip_or_domain_name}:8443/ontologies/{ontology_acronym}/latest_submission?include=all`
+
+You can look for the `submissionStatus` attribute to get the status.
+
+If you are looking at an ontology that should have been parsed some time ago,
+you can look at the Ontology Administration tab of the Administration Console page.
+See <a href="{{site.baseurl}}/administration-guide/ontologies/troubleshooting_submissions">Troubleshooting Submissions</a> for more information.
+
+## Is there a log file for parsing?
+
+Parsing progress is logged in the ontology submission repository folder:
+
+`/srv/ontoportal/data/repository/{ontology acronym}/{submission id}`
+
+You can also see the latest log from the Ontology Administration tab of the Administration Console page.
+See <a href="{{site.baseurl}}/administration-guide/ontologies/troubleshooting_submissions">Troubleshooting Submissions</a> for more information.
+
+For further information about ontology parsing,
+please see <a href="{{site.baseurl}}/administration-guide/ontologies/parseable_ontologies">Parseable Ontologies</a>
+and <a href="{{site.baseurl}}/administration-guide/ontologies/troubleshooting_submissions">Troubleshooting Submissions</a>.

--- a/docs/administration-guide/installation/v41/allegrograph_configuration.md
+++ b/docs/administration-guide/installation/v41/allegrograph_configuration.md
@@ -1,0 +1,15 @@
+---
+title: AllegroGraph Configuration
+layout: default
+summary: Configuring your system to run AllegroGraph
+status: Needs revision
+nav_exclude: true
+parent: Installation Steps
+grand_parent: Administration Guide
+permalink: /administration-guide/steps/allegrograph_configuration/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/installation/v41/allegrograph_configuration.md %}

--- a/docs/administration-guide/management/v41/annotator_management.md
+++ b/docs/administration-guide/management/v41/annotator_management.md
@@ -1,0 +1,15 @@
+---
+title: Annotator Management
+layout: default
+summary: Operations on the annotator
+status: In progress
+nav_exclude: true
+parent: System Management
+grand_parent: Administration Guide
+permalink: /administration-guide/management/annotator_management/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/management/v41/annotator_management.md %}

--- a/docs/administration-guide/management/v41/google_analytics_management.md
+++ b/docs/administration-guide/management/v41/google_analytics_management.md
@@ -1,0 +1,14 @@
+---
+title: Google Analytics Management
+layout: default
+summary: Setting up Google Analytics tracking for your Appliance
+nav_exclude: true
+parent: System Management
+grand_parent: Administration Guide
+permalink: /administration-guide/management/google_analytics_management/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/management/v41/google_analytics_management.md %}

--- a/docs/administration-guide/management/v41/reference_ncbo-cron.md
+++ b/docs/administration-guide/management/v41/reference_ncbo-cron.md
@@ -1,0 +1,14 @@
+---
+title: ncbo-cron Reference
+layout: default
+summary: Advanced information about ncbo-cron
+nav_exclude: true
+parent: System Management
+grand_parent: Administration Guide
+permalink: /administration-guide/management/ncbo_cron/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/management/v41/reference_ncbo-cron.md %}

--- a/docs/administration-guide/management/v41/routine_operations.md
+++ b/docs/administration-guide/management/v41/routine_operations.md
@@ -1,0 +1,14 @@
+---
+title: Routine Administrative Operations
+layout: default
+summary: Performing routine tasks in the OntoPortal system
+nav_exclude: true
+parent: System Management
+grand_parent: Administration Guide
+permalink: /administration-guide/management/routine_operations/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/management/v41/routine_operations.md %}

--- a/docs/administration-guide/management/v41/search_index_management.md
+++ b/docs/administration-guide/management/v41/search_index_management.md
@@ -1,0 +1,14 @@
+---
+title: Search Index Management
+layout: default
+summary: Operations on the Solr search index
+nav_exclude: true
+parent: System Management
+grand_parent: Administration Guide
+permalink: /administration-guide/management/search_index_management/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/management/v41/search_index_management.md %}

--- a/docs/administration-guide/ontologies/v41/managing_ontologies.md
+++ b/docs/administration-guide/ontologies/v41/managing_ontologies.md
@@ -1,0 +1,14 @@
+---
+title: Managing Ontologies
+layout: default
+summary: How to manage your repository's ontologies
+nav_exclude: true
+parent: Managing Content
+grand_parent: Administration Guide
+permalink: /administration-guide/ontologies/managing_ontologies/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/ontologies/v41/managing_ontologies.md %}

--- a/docs/administration-guide/ontologies/v41/submitting_ontologies.md
+++ b/docs/administration-guide/ontologies/v41/submitting_ontologies.md
@@ -1,0 +1,14 @@
+---
+title: Submitting Ontologies
+layout: default
+summary: How to submit ontology files to your repository
+nav_exclude: true
+parent: Managing Content
+grand_parent: Administration Guide
+permalink: /administration-guide/ontologies/submitting_ontologies/v41
+version: "v41"
+---
+
+{% include admin_nav.html %}
+
+{% include shared_admin/ontologies/v41/submitting_ontologies.md %}


### PR DESCRIPTION
## Summary

After an exhaustive comparison against alexskr's Appliance v4.1 docs, these 8 pages have genuinely different commands/paths between v3.2 and v4.1. Add a v4.1 view for each so the appliance version switcher appears (default `+/v41` pattern; v3.2 wrappers already carry `version: v32` + `admin_nav`).

Content is taken from `alexskr/documentation@appliance_v4`, with internal links fixed to `/administration-guide/` and `/developer-guide/`.

| Page | v4.1 difference |
|---|---|
| `installation/allegrograph_configuration` | Note: AllegroGraph is the **default** in v4.0+ — nothing to switch |
| `management/annotator_management` | `/opt` paths, `op-admin`, `systemctl`/`opctl` |
| `management/routine_operations` | `/opt/ontoportal/ncbo_cron`, rake tasks |
| `management/google_analytics_management` | GA4 config, `op-admin`, `systemctl` |
| `management/reference_ncbo-cron` | `/opt` code paths, `op-admin` |
| `management/search_index_management` | `/opt/ontoportal/ncbo_cron`, `op-admin` |
| `ontologies/submitting_ontologies` | `op-admin`, `/opt/ontoportal/ncbo_cron` |
| `ontologies/managing_ontologies` | `op-admin`, `/opt/ontoportal/ncbo_cron` |

Pages that had markers but that alexskr did **not** update for v4.1 (`appliance_upgrade`, `appliance_upgrade_v25_to_31`, `reference_sparql_endpoint`) were intentionally left unchanged.

## Test plan (verified on localhost, clean rebuild)

- [x] Version switcher appears on all 8 v3.2 pages and cross-links correctly
- [x] Each v4.1 view renders and shows the v4.1-specific content (`/opt`, `op-admin`, …)
- [x] No Jekyll build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)